### PR TITLE
이유리 벽돌깨기 수정본 제출합니다.

### DIFF
--- a/Yuri/Week06/SWEA_벽돌깨기_5656.java
+++ b/Yuri/Week06/SWEA_벽돌깨기_5656.java
@@ -58,7 +58,7 @@ public class Solution {
                 // 현재 열에서 가장 위의 블럭을 찾는다.
                 Point block = findTopBlock(num);
                 if(block == null)   // 만약 맨 위 블럭이 없다면 (n-1번째까지 전부 0이면) 반복 중지.
-                    break;
+                    continue;
                 // 가장 위의 블럭 터트리기 (연쇄 반응으로 터지는 모든 블럭을 탐색한 후 전부 터트린다.)
                 boomNum += bomb(block);
                 // 남은 블럭 전부 아래로 내리기.


### PR DESCRIPTION
순열대로 열을 탐색할 때, 해당 열의 맨 위 블럭이 없는 경우 다음 열도 탐색해야하는데, break하여 다음 열 탐색을 막아버림. 
SWEA에서 풀리는 이유를 모르겠음?????
하지만 continue가 맞는듯하여 수정하여 제출합니다.